### PR TITLE
improve handling,styling, and alignment of ODF/ODT files

### DIFF
--- a/extractZIP.js
+++ b/extractZIP.js
@@ -46,8 +46,11 @@ class ZIPExtractor {
     }
   }
 
+
   extractFile (path) {
-    const fileInfo = this.files.get(path);
+    const fileInfo = this.files.get(
+      path.startsWith("./") ? path.slice(2) : path
+    );
     if (!fileInfo) throw new Error(`File not found: ${path}`);
 
     let offset = fileInfo.localHeaderOffset;


### PR DESCRIPTION
This PR improve support for ODF files. (you can see each fix individually in [here](https://github.com/matan-h/envelope-fork/commits/main))

- support loext:graphic-properties fill (all types)
- support style:parent-style-name
- fix paragraph position
- fix table cells and image position
- fix crash on file with embedded objects
- handle z-index correctly